### PR TITLE
fix: fix spm imports

### DIFF
--- a/mParticle_Optimizely/mParticle_Optimizely.h
+++ b/mParticle_Optimizely/mParticle_Optimizely.h
@@ -4,4 +4,8 @@ FOUNDATION_EXPORT double mParticle_OptimizelyVersionNumber;
 
 FOUNDATION_EXPORT const unsigned char mParticle_OptimizelyVersionString[];
 
+#if defined(__has_include) && __has_include(<mParticle_Optimizely/MPKitOptimizely.h>)
 #import <mParticle_Optimizely/MPKitOptimizely.h>
+#else
+#import "MPKitOptimizely.h"
+#endif


### PR DESCRIPTION
# Summary

While trying to import the package into one of their swift files a developer was getting the following error "Could not build objective-c module mParticle_Adobe".

Tested through targeting this branch with SPM in in swift example app.
