### PR TITLE
feat: Add Privacy Manifest and SPM Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ playground.xcworkspace
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
 # Packages/
 .build/
+Package.resolved
 
 # CocoaPods
 #

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+import PackageDescription
+let package = Package(
+    name: "mParticle-Optimizely",
+    platforms: [ .iOS(.v10), .tvOS(.v10) ],
+    products: [
+        .library(
+            name: "mParticle-Optimizely",
+            targets: ["mParticle_Optimizely"]),
+    ],
+    dependencies: [
+      .package(name: "mParticle-Apple-SDK",
+               url: "https://github.com/mParticle/mparticle-apple-sdk",
+               .upToNextMajor(from: "8.0.0")),
+      .package(name: "Optimizely",
+               url: "https://github.com/optimizely/swift-sdk",
+               .upToNextMajor(from: "4.0.0")),
+    ],
+    targets: [
+        .target(
+            name: "mParticle_Optimizely",
+            dependencies: ["mParticle-Apple-SDK", "Optimizely"],
+            path: "mParticle_Optimizely",
+            publicHeadersPath: "."
+        ),
+    ]
+)

--- a/mParticle-Optimizely.podspec
+++ b/mParticle-Optimizely.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
     s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-optimizely.git", :tag => s.version.to_s }
     s.social_media_url = "https://twitter.com/mparticle"
     s.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
-    s.dependency 'OptimizelySwiftSDK', '~> 3.0'
+    s.dependency 'OptimizelySwiftSDK', '~> 4.0'
     s.swift_versions = ['5.0']
 
     s.ios.deployment_target = "10.0"

--- a/mParticle_Optimizely.xcodeproj/project.pbxproj
+++ b/mParticle_Optimizely.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		D377139824042B1000CF4773 /* Optimizely.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D37713932404247E00CF4773 /* Optimizely.framework */; };
 		D377139924042B2200CF4773 /* mParticle_Apple_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D37713952404249200CF4773 /* mParticle_Apple_SDK.framework */; };
 		D377139B24042B2200CF4773 /* OCMock.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D377139A24042B2200CF4773 /* OCMock.framework */; };
+		D3B8187D2BC6C002001F09BB /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D3B8187C2BC6C002001F09BB /* PrivacyInfo.xcprivacy */; };
+		D3B8187E2BC6C002001F09BB /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D3B8187C2BC6C002001F09BB /* PrivacyInfo.xcprivacy */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -62,6 +64,7 @@
 		D37713932404247E00CF4773 /* Optimizely.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Optimizely.framework; path = Carthage/Build/tvOS/Optimizely.framework; sourceTree = "<group>"; };
 		D37713952404249200CF4773 /* mParticle_Apple_SDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = mParticle_Apple_SDK.framework; path = Carthage/Build/tvOS/mParticle_Apple_SDK.framework; sourceTree = "<group>"; };
 		D377139A24042B2200CF4773 /* OCMock.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OCMock.framework; path = Carthage/Build/tvOS/OCMock.framework; sourceTree = "<group>"; };
+		D3B8187C2BC6C002001F09BB /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -152,6 +155,7 @@
 				D316BD4D217F67BC00688E56 /* MPKitOptimizely.m */,
 				D316BD35217F670500688E56 /* mParticle_Optimizely.h */,
 				D316BD36217F670600688E56 /* Info.plist */,
+				D3B8187C2BC6C002001F09BB /* PrivacyInfo.xcprivacy */,
 			);
 			path = mParticle_Optimizely;
 			sourceTree = "<group>";
@@ -323,6 +327,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D3B8187E2BC6C002001F09BB /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -337,6 +342,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D3B8187D2BC6C002001F09BB /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/mParticle_Optimizely/PrivacyInfo.xcprivacy
+++ b/mParticle_Optimizely/PrivacyInfo.xcprivacy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict/>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict/>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
 - Update to latest version of the SDK with privacy manifest and add our own privacy manifest to the kit

 ## Testing Plan
 - Tested locally and confirmed end to end

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6298
